### PR TITLE
Improve drag gesture logic

### DIFF
--- a/Sources/ModernSlider/ModernSlider.swift
+++ b/Sources/ModernSlider/ModernSlider.swift
@@ -144,7 +144,7 @@ private struct SliderView: View {
     @GestureState private var dragOffsetY: CGFloat = 0
     @State private var isTapped = false
     
-    private let tapAnimation: Animation? = .smooth(duration: 0.3, extraBounce: 0.0)
+    private let tapAnimation: Animation? = .smooth(duration: 0.38, extraBounce: 0.0)
     
     private var halfThumbSize: CGFloat {
         sliderHeight / 2


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/5f13252d-08c1-4de2-8288-50277a1da4ad

## After

https://github.com/user-attachments/assets/cac436a6-e93a-47c7-98ac-c68da381ad10

## Apple's own slider

https://github.com/user-attachments/assets/2d004614-7018-4b96-b4a8-6c577e490f20


## Code explanation
I have added a second `DragGesture` to work alongside the existing drag gesture. The purpose of this new gesture is to detect situations where the user is tapping on the slider rather than dragging it. 

Here’s the desired behavior:
- **For Taps**: If the user taps on the slider to update its value, the knob and the track should animate smoothly.
- **For Drags**: If the user drags the knob, no animation should be applied, ensuring a smooth and responsive experience.

### Why Not Use `TapGesture`?  
The reason for not using `TapGesture` is that its `onChange` method is triggered only after the user lifts their finger. What we need instead is a way to detect the **touch-down event** without any movement. This approach allows us to treat it as a "tap" and animate the slider immediately, mimicking Apple’s behaviour in similar components. 

Let me know if you’d like further refinements or code snippets!
